### PR TITLE
Flask OCIO example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,2 @@
-flask/gpuopen/materialx_gpuopen_app.egg-info/
-flask/gpuopen/__pycache__/
-flask/converters/__pycache__/
-flask/template/template_flask_app.egg-info/
-flask/template/__pycache__/
+*__pycache__/
+*.egg-info/

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The main focus is on connection "open standards" such as `gltF`, `OCIO`, `OpenUS
 
 ## Flask Connector Examples
 
-- [GPUOpen MaterialX Materials](/flask/gpuopen/README.md)
-- [glTF and USD Convertors for MaterialX](/flask/converters/README.md)
-- OCIO to MaterialX Definition Generation (forth-coming)
-
+- [GPUOpen MaterialX Materials Inspector](./flask/gpuopen/README.md)
+- [glTF and USD Conversion from MaterialX](./flask/converters/README.md)
+- [OCIO to MaterialX Definition Generation (Alpha)](./flask/ocio/README.md)
+- [Simple template example](./flask/template/README.md)

--- a/flask/ocio/README.md
+++ b/flask/ocio/README.md
@@ -1,0 +1,53 @@
+## MaterialX OCIO Application
+
+MaterialX OCIO Flask App. Reads in default AcesCG config from OCIO and allows
+for generation of supported MaterialX definitions either in source code or
+graph form.
+
+Note: This is just a sample application with graph generation still in progress.
+
+### Dependents
+- `flask` and `flask-socketio` Python packages
+- `socket-io` Javascript library
+- `materialxocio` MaterialX / OCIO library which contains logic for generation.
+
+### Installation
+
+Either install the package from `PyPi`:
+
+```
+pip install materialx_ocio_app
+```
+
+or clone the <a href="https://github.com/kwokcb/materialxWeb">materialXWeb</a>  
+repository and install from the `flast/ocio` folder under the root:
+
+```
+pip install .
+```
+
+or 
+
+```
+pip install -e .
+```
+if planning to perform edits on the repository.
+
+### Execution
+
+Run the main package using:
+```
+materialx_ocio_app
+```
+or directly with Python:
+```
+python materialx_ocio_app.py
+```
+
+By default the application is running a local server. To access the client page open the following in a Web browser:
+```
+http://127.0.0.1:5002
+```
+
+
+

--- a/flask/ocio/materialx_ocio_app.py
+++ b/flask/ocio/materialx_ocio_app.py
@@ -94,7 +94,7 @@ class materialx_ocio_app(MaterialXFlaskApp):
         self.configs, self.aconfig = self.generator.getBuiltinConfigs()
         self.config_info = self.generator.printConfigs(self.configs)
  
-        emit('server_message_1', { 'message': self.config_info }, broadcast=True)
+        emit('server_message_get_config_info', { 'message': self.config_info }, broadcast=True)
 
     def get_materialx_info(self, targetColorSpace, createGraphs):
         configs, aconfig = self.generator.getBuiltinConfigs()
@@ -173,8 +173,12 @@ class materialx_ocio_app(MaterialXFlaskApp):
 
         print('> Generatated MaterialX', result != None)
         
-        #server_message_2 = 'Using OCIO Version: ' + self.OCIO_version + '. MaterialX Version: ' + self.materialx_version
-        emit('server_message_2', { 'message': result }, broadcast=True)
+        #server_message_get_mtlx_info = 'Using OCIO Version: ' + self.OCIO_version + '. MaterialX Version: ' + self.materialx_version
+        emit('server_message_get_mtlx_info', { 'message': result }, broadcast=True)
+
+    def handle_get_version_info(self, data):
+        #server_message_get_mtlx_info = 'Using OCIO Version: ' + self.OCIO_version + '. MaterialX Version: ' + self.materialx_version
+        emit('server_message_get_mtlx_info', { 'message': result }, broadcast=True)
 
     def _setup_event_handler_map(self):
         """

--- a/flask/ocio/materialx_ocio_app.py
+++ b/flask/ocio/materialx_ocio_app.py
@@ -1,0 +1,109 @@
+'''
+@file materialx_ocio_app.py
+@brief __PYTHON_APP_DESCRIPTION__
+'''
+import argparse
+from flask import Flask, render_template
+from flask_socketio import SocketIO, emit
+
+class MaterialXFlaskApp:
+    def __init__(self, home):
+        self.home = home
+
+        # Initialize Flask and SocketIO
+        self.app = Flask(__name__)
+        self.socketio = SocketIO(self.app)
+
+        # Register routes and events
+        self._register_routes()
+        self._setup_event_handler_map()
+        self._register_socket_events()
+
+    def _register_routes(self):
+        """
+        Register HTTP routes.
+        """
+        @self.app.route('/')
+        def home():
+            """
+            Render the home page.
+            """
+            #status_message = f'Startup: Using MaterialX version: {mx.getVersionString()}'
+            #self._emit_status_message(status_message)
+            return render_template(self.home)
+
+    def _setup_event_handler_map(self):
+        """Pure virtual method: Must be implemented by subclasses."""
+        raise NotImplementedError("Subclasses must implement _setup_event_handler_map")
+
+    def _register_socket_events(self):
+        """
+        Register SocketIO events.
+        """
+        # Dynamically register event handlers
+        for event_name, handler in self.event_handlers.items():
+            self.socketio.on_event(event_name, handler)        
+
+    def run(self, host, port, debug=True):
+        """
+        Run the Flask server with SocketIO.
+        """
+        self.socketio.run(self.app, host, port, debug=debug)
+
+
+class materialx_ocio_app(MaterialXFlaskApp):
+    '''
+    '''
+    def __init__(self, homePage):
+        """
+        Initialize the Flask application and the MaterialX loader.
+        """
+        super().__init__(homePage)
+
+    def _emit_status_message(self, message):
+        """
+        Emit a status message to the client.
+        """
+        emit('status_message', { 'message': message }, broadcast=True)
+
+    def _handle_client_event_1(self, data):
+        '''
+        Handle event and send back server message 1
+        '''
+        event_data = data.get('message', 'Message')
+        server_message_1 = "server handled: " + event_data
+        emit('server_message_1', { 'message': server_message_1 }, broadcast=True)
+
+    def _handle_client_event_2(self, data):
+        '''
+        Handle event and send back server message 2
+        '''
+        event_data = data.get('message', 'Message')
+        server_message_2 = "server handled: " + event_data
+        emit('server_message_1', { 'message': server_message_2 }, broadcast=True)
+
+    def _setup_event_handler_map(self):
+        """
+        Set up dictionary of mapping event names to their handlers
+        """
+        self.event_handlers = {
+            'client_event_1': self._handle_client_event_1,
+            'client_event_2': self._handle_client_event_2,
+        }
+
+# Main entry point
+def main(): 
+    parser = argparse.ArgumentParser(description="__PYTHON_PROJECT_DESCRIPTION__")
+    parser.add_argument('--host', type=str, default='127.0.0.1', help="Host address to run the server on (default: 127.0.0.1)")
+    parser.add_argument('--port', type=int, default=5002, help="Port to run the server on (default: 5002)")
+    parser.add_argument('--home', type=str, default='materialx_ocio_app.html', help="Home page.")
+
+    args = parser.parse_args()
+
+    app = materialx_ocio_app(args.home)
+    app_host = args.host
+    app_port = args.port
+    app.run(host=app_host, port=app_port)
+
+if __name__ == '__main__':
+    main()

--- a/flask/ocio/materialx_ocio_app.py
+++ b/flask/ocio/materialx_ocio_app.py
@@ -177,21 +177,27 @@ class materialx_ocio_app(MaterialXFlaskApp):
         emit('server_message_get_mtlx_info', { 'message': result }, broadcast=True)
 
     def handle_get_version_info(self, data):
-        #server_message_get_mtlx_info = 'Using OCIO Version: ' + self.OCIO_version + '. MaterialX Version: ' + self.materialx_version
-        emit('server_message_get_mtlx_info', { 'message': result }, broadcast=True)
+        print('> Get version information')
+        emit('server_message_version_info', 
+            {   
+                'ocio_version': self.OCIO_version,
+                'materialx_version':  self.materialx_version 
+            },
+            broadcast=True)
 
     def _setup_event_handler_map(self):
         """
         Set up dictionary of mapping event names to their handlers
         """
         self.event_handlers = {
+            'client_event_get_version_info': self.handle_get_version_info,
             'client_event_get_config_info': self.handle_get_config_info,
             'client_event_get_materialx_info': self.handle_get_materialx_info,
         }
 
 # Main entry point
 def main(): 
-    parser = argparse.ArgumentParser(description="__PYTHON_PROJECT_DESCRIPTION__")
+    parser = argparse.ArgumentParser(description="Application to use the OCIO package to extract out configuration information and generate MaterialX definitions")
     parser.add_argument('--host', type=str, default='127.0.0.1', help="Host address to run the server on (default: 127.0.0.1)")
     parser.add_argument('--port', type=int, default=5002, help="Port to run the server on (default: 5002)")
     parser.add_argument('--home', type=str, default='materialx_ocio_app.html', help="Home page.")

--- a/flask/ocio/pyproject.toml
+++ b/flask/ocio/pyproject.toml
@@ -1,0 +1,49 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "materialx_ocio_app"
+version = "0.0.1"
+description = "MaterialX generation from OCIO"
+readme = "README.md"
+requires-python = ">=3.8"
+license = {file = "LICENSE"}
+authors = [
+    {name = "Bernard Kwok", email = "kwokcb@gmail.com"}
+]
+classifiers = [
+    "Intended Audience :: Developers",
+    "Programming Language :: Python :: 3",
+    "License :: OSI Approved :: Apache Software License",
+    "Operating System :: OS Independent",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+]
+dependencies = [
+    "flask>=2.3.2",
+    "flask-socketio>=5.3.4",
+    "argparse>=1.4.0",
+    "materialx>=1.38.9",
+    "opencolorio>=2.2.0",    
+    "materialxocio>=0.1.39.0.1"    
+]
+
+[project.scripts]
+materialx_ocio_app = "materialx_ocio_app:main"
+
+[tool.setuptools.packages.find]
+where = ["."] 
+
+[tool.setuptools.package-data]
+"materialx_ocio_app" = [
+    "data/*",
+    "static/css/*",
+    "static/js/*",
+    "templates/*",
+]
+
+[project.urls]
+"Homepage" = "https://kwokcb.github.io/materialxocio/docs/html/"
+"Issues" = "https://github.com/kwokcb/materialxocio/issues"
+"Source Code" = "https://github.com/kwokcb/materialxWeb"
+"Documentation" = "https://kwokcb.github.io/materialxocio/docs/html/"

--- a/flask/ocio/static/js/WebSocketClient.js
+++ b/flask/ocio/static/js/WebSocketClient.js
@@ -1,0 +1,59 @@
+export class WebSocketClient
+{
+    constructor(socketLibrary, server) {
+        this.socket = null;
+        this.initialize(socketLibrary, server);
+    }
+
+    async initialize(socketLibrary, server) {
+        try {
+            if (!socketLibrary || socketLibrary.len == 0)
+            {
+                socketLibrary = "https://cdnjs.cloudflare.com/ajax/libs/socket.io/4.5.4/socket.io.esm.min.js";
+            }
+            console.log(socketLibrary)
+            // Dynamically load socket.io from CDN
+            const { io } = await import(socketLibrary);
+            
+            // Initialize the socket connection
+            if (server && server.len > 0)
+            {
+                this.socket = io(server); 
+            }
+            else
+            {
+                this.socket = io();
+            }
+            console.log('Initialized socket.io')
+
+            this.setupEventHandlers();
+
+        } catch (error) {
+            console.error('Failed to load socket.io:', error);
+        }
+    }
+
+    setupEventHandlers() {
+        // Empty. Derived classes can override this          
+    }
+    
+    emit(message, data) {
+        this.socket.emit(message, data);
+    }
+}
+
+export class WebSocketEventHandlers {    
+    constructor(socket, eventHandlers) {
+        console.log('Create event handlers:', eventHandlers)
+        this.socket = socket;
+        this.eventHandlers = eventHandlers;
+        this.setupEventListeners();
+    }
+
+    setupEventListeners() {
+        // Iterate over the event handlers and bind them to the socket
+        for (const [eventName, handler] of Object.entries(this.eventHandlers)) {
+            this.socket.on(eventName, handler);
+        }
+    }
+}

--- a/flask/ocio/static/js/materialx_ocio_app.js
+++ b/flask/ocio/static/js/materialx_ocio_app.js
@@ -46,6 +46,11 @@ export class templateClient extends WebSocketClient {
         this.convertTableToBootstrapRowCol(configDOM);
     }
 
+    updateMaterialXInfo(message) {
+        const materialxDOM = document.getElementById('materialX_info')
+        materialxDOM.value = message;
+    }
+
     updateStatus(message, force = false) {
         const inputDOM = document.getElementById('status_message');
         if (inputDOM.value == 'Status' || force)
@@ -56,24 +61,24 @@ export class templateClient extends WebSocketClient {
         inputDOM.scrollTop = inputDOM.scrollHeight;
     }
 
-    emitEvent1() {
-        console.log("WEB: Emitting client_event_1 event");
-        this.emit('client_event_1', { message: "event 1" });
+    emitGetConfigInfo() {
+        this.updateStatus("Emit client_event_get_config_info event");
+        this.emit('client_event_get_config_info', { message: "event 1" });
     }
 
-    emitEvent2() {
-        console.log("WEB: Emitting client_event_2 event");
-        this.emit('client_event_2', { message: "event 2" });
+    getMaterialXInfo() {
+        this.updateStatus("Emit client_event_get_materialx_info event");
+        this.emit('client_event_get_materialx_info', { message: "event 2" });
     }
 
-    handleServerMessage1(data) {
-        console.log("WEB: Receive server message 1");
+    handleServerConfigInfo(data) {
+        this.updateStatus("Received server config info");
         this.updateConfigInfo(data.message);
     }
 
-    handleServerMessage2(data) {
-        console.log("WEB: Receive server message 2");
-        this.updateStatus(data.message);
+    handleServerMaterialXInfo(data) {
+        this.updateStatus("Received server materialx info");
+        this.updateMaterialXInfo(data.message);
     }
 
     setupEventHandlers() {
@@ -82,21 +87,19 @@ export class templateClient extends WebSocketClient {
             this.updateStatus('Status', true);
         });
 
-        // Bind event 1 to button click
-        document.getElementById('button_event_1').addEventListener('click', () => {
-            this.emitEvent1();
+        document.getElementById('button_event_get_config').addEventListener('click', () => {
+            this.emitGetConfigInfo();
         });
 
-        // Bind event 2 button click
-        document.getElementById('button_event_2').addEventListener('click', () => {
-            this.emitEvent2();
+        document.getElementById('button_event_get_materialx').addEventListener('click', () => {
+            this.getMaterialXInfo();
         });
 
         // Set up socket message event handlers
         this.webSocketWrapper = new WebSocketEventHandlers(this.socket, {
             status_message: (data) => { console.log('WEB: status event:', data.message); this.updateStatus(data.message) },
-            server_message_1: (data) => { this.handleServerMessage1(data) },
-            server_message_2: (data) => { this.handleServerMessage2(data) }
+            server_message_1: (data) => { this.handleServerConfigInfo(data) },
+            server_message_2: (data) => { this.handleServerMaterialXInfo(data) }
         });
     }
 }

--- a/flask/ocio/static/js/materialx_ocio_app.js
+++ b/flask/ocio/static/js/materialx_ocio_app.js
@@ -66,7 +66,10 @@ export class MaterialXOCIOClient extends WebSocketClient {
             elem.style.display = 'block'
             elem.value = content;
             const lines = content.split(/\r?\n/);
-            elem.rows = lines.length;
+            if (lines.length < 30)
+                elem.rows = lines.length;
+            else
+                elem.rows = 30;
         }
         else {
             elem.style.display = 'none'
@@ -80,7 +83,10 @@ export class MaterialXOCIOClient extends WebSocketClient {
             elem.style.display = 'block'
             elem.value = content;
             const lines = content.split(/\r?\n/);
-            elem.rows = lines.length;
+            if (lines.length < 10)
+                elem.rows = lines.length;
+            else
+                elem.rows = 10;
         }
         else {
             elem.style.display = 'none'

--- a/flask/ocio/static/js/materialx_ocio_app.js
+++ b/flask/ocio/static/js/materialx_ocio_app.js
@@ -7,6 +7,8 @@ export class MaterialXOCIOClient extends WebSocketClient {
 
         // Do other setup
         this.materialXEditor = null;
+        this.materialXEditor_impl = null;
+        this.materialXEditor_source = null;
     }
 
     convertTableToBootstrapRowCol(container) {
@@ -47,10 +49,42 @@ export class MaterialXOCIOClient extends WebSocketClient {
         this.convertTableToBootstrapRowCol(configDOM);
     }
 
-    updateMaterialXInfo(message) {
-        //const materialxDOM = document.getElementById('materialX_info')
-        //materialxDOM.value = message;
-        this.materialXEditor.setValue(message);
+    updateMaterialXInfo(data) {
+        console.log('Nodedef:\n',
+            data.nodedef_string, "\nImpl: ",
+            data.impl_string, "\nSource: ",
+            data.source_string
+        );
+
+        this.materialXEditor.setValue(data.nodedef_string);
+
+        let elem = document.getElementById('materialX_impl');
+        let content = data.impl_string;
+        if (content)
+        {
+            content = content.replace(/^\s*[\r\n]+|[\r\n]+\s*$/g, '');
+            elem.style.display = 'block'
+            elem.value = content;
+            const lines = content.split(/\r?\n/);
+            elem.rows = lines.length;
+        }
+        else {
+            elem.style.display = 'none'
+        }
+
+        elem = document.getElementById('materialX_source')
+        content = data.source_string;
+        if (content)
+        {
+            content = content.replace(/^\s*[\r\n]+|[\r\n]+\s*$/g, '');
+            elem.style.display = 'block'
+            elem.value = content;
+            const lines = content.split(/\r?\n/);
+            elem.rows = lines.length;
+        }
+        else {
+            elem.style.display = 'none'
+        }
     }
 
     updateStatus(message, force = false) {
@@ -70,7 +104,12 @@ export class MaterialXOCIOClient extends WebSocketClient {
 
     getMaterialXInfo() {
         this.updateStatus("Emit client_event_get_materialx_info event");
-        this.emit('client_event_get_materialx_info', { message: "event 2" });
+        let checkbox_nodegraphs = document.getElementById('checkbox_nodegraphs').checked
+        this.emit('client_event_get_materialx_info', 
+            { 
+                nodegraphs: checkbox_nodegraphs 
+            }
+        );
     }
 
     handleServerConfigInfo(data) {
@@ -80,7 +119,7 @@ export class MaterialXOCIOClient extends WebSocketClient {
 
     handleServerMaterialXInfo(data) {
         this.updateStatus("Received server materialx info");
-        this.updateMaterialXInfo(data.message);
+        this.updateMaterialXInfo(data);
     }
 
     handleServerVersionInfo(data) {
@@ -122,23 +161,33 @@ export class MaterialXOCIOClient extends WebSocketClient {
     }
     
     setupXML() {
-        /* 
-        const materialXTextArea = document.getElementById('mtlxOutput');
-        this.editor = CodeMirror.fromTextArea(materialXTextArea, {
-            mode: 'application/json',
-            lineNumbers: true,
-            theme: 'dracula',
-        });
-        this.editor.setSize('auto', '300px');
-        */
-
         // Initialize CodeMirror for MaterialX content
-        const materialXTextArea2 = document.getElementById('materialX_info');
-        this.materialXEditor = CodeMirror.fromTextArea(materialXTextArea2, {
+        const materialX_nodedef = document.getElementById('materialX_nodedef');
+        this.materialXEditor = CodeMirror.fromTextArea(materialX_nodedef, {
             mode: 'application/xml',
             lineNumbers: true,
             theme: 'dracula',
         });
         this.materialXEditor.setSize('auto', '300px');
+
+        /*
+        const materialX_impl = document.getElementById('materialX_nodedef');
+        this.materialXEditor_impl = CodeMirror.fromTextArea(materialX_impl, {
+            mode: 'application/xml',
+            lineNumbers: true,
+            theme: 'dracula',
+        });
+        this.materialXEditor_impl.setSize('auto', '100px');
+        //this.materialXEditor_impl.setDisplay('none')
+
+        const materialx_source = document.getElementById('materialx_source');
+        this.materialXEditor_source = CodeMirror.fromTextArea(materialx_source, {
+            mode: 'application/xml',
+            lineNumbers: true,
+            theme: 'dracula',
+        });
+        this.materialXEditor_source.setSize('auto', '100px');
+        //this.materialXEditor_source.setDisplay('none')
+        */
     }
 }

--- a/flask/ocio/static/js/materialx_ocio_app.js
+++ b/flask/ocio/static/js/materialx_ocio_app.js
@@ -1,11 +1,12 @@
 import { WebSocketClient, WebSocketEventHandlers } from './WebSocketClient.js';
 
-export class templateClient extends WebSocketClient {
+export class MaterialXOCIOClient extends WebSocketClient {
     constructor(socketLibrary, server) {
         // Call parent to setup socket I/O.
         super(socketLibrary, server);
 
         // Do other setup
+        this.materialXEditor = null;
     }
 
     convertTableToBootstrapRowCol(container) {
@@ -47,8 +48,9 @@ export class templateClient extends WebSocketClient {
     }
 
     updateMaterialXInfo(message) {
-        const materialxDOM = document.getElementById('materialX_info')
-        materialxDOM.value = message;
+        //const materialxDOM = document.getElementById('materialX_info')
+        //materialxDOM.value = message;
+        this.materialXEditor.setValue(message);
     }
 
     updateStatus(message, force = false) {
@@ -98,9 +100,29 @@ export class templateClient extends WebSocketClient {
         // Set up socket message event handlers
         this.webSocketWrapper = new WebSocketEventHandlers(this.socket, {
             status_message: (data) => { console.log('WEB: status event:', data.message); this.updateStatus(data.message) },
-            server_message_1: (data) => { this.handleServerConfigInfo(data) },
-            server_message_2: (data) => { this.handleServerMaterialXInfo(data) }
+            server_message_get_config_info: (data) => { this.handleServerConfigInfo(data) },
+            server_message_get_mtlx_info: (data) => { this.handleServerMaterialXInfo(data) }
         });
     }
-}
+    
+    setupXML() {
+        /* 
+        const materialXTextArea = document.getElementById('mtlxOutput');
+        this.editor = CodeMirror.fromTextArea(materialXTextArea, {
+            mode: 'application/json',
+            lineNumbers: true,
+            theme: 'dracula',
+        });
+        this.editor.setSize('auto', '300px');
+        */
 
+        // Initialize CodeMirror for MaterialX content
+        const materialXTextArea2 = document.getElementById('materialX_info');
+        this.materialXEditor = CodeMirror.fromTextArea(materialXTextArea2, {
+            mode: 'application/xml',
+            lineNumbers: true,
+            theme: 'dracula',
+        });
+        this.materialXEditor.setSize('auto', '300px');
+    }
+}

--- a/flask/ocio/static/js/materialx_ocio_app.js
+++ b/flask/ocio/static/js/materialx_ocio_app.js
@@ -1,0 +1,69 @@
+import { WebSocketClient,  WebSocketEventHandlers } from './WebSocketClient.js';
+
+export class templateClient extends WebSocketClient
+{
+    constructor(socketLibrary, server) {
+        // Call parent to setup socket I/O.
+        super(socketLibrary, server);
+        
+        // Do other setup
+    }
+
+    updateStatus(message, force = false) 
+    {
+        const inputDOM = document.getElementById('status_message');
+        if (inputDOM.value == 'Status' || force)        
+            inputDOM.value = message
+        else
+            inputDOM.value += '\n' + message
+        // Scroll to the bottom of the textarea
+        inputDOM.scrollTop = inputDOM.scrollHeight;
+    }
+
+    emitEvent1() {
+        console.log("WEB: Emitting client_event_1 event");
+        this.emit('client_event_1', { message: "event 1" });
+    }
+
+    emitEvent2() {
+        console.log("WEB: Emitting client_event_2 event");
+        this.emit('client_event_2', { message: "event 2" });
+    }
+
+    handleServerMessage1(data)
+    {
+        console.log("WEB: Receive server message 1");
+        this.updateStatus(data.message);
+    }
+
+    handleServerMessage2(data)
+    {
+        console.log("WEB: Receive server message 2");
+        this.updateStatus(data.message);       
+    }
+
+    setupEventHandlers() {
+        // Setup clear status button
+        document.getElementById('clear_status').addEventListener('click', () => {
+            this.updateStatus('Status', true);
+        });
+
+        // Bind event 1 to button click
+        document.getElementById('button_event_1').addEventListener('click', () => {
+            this.emitEvent1();
+        });
+
+        // Bind event 2 button click
+        document.getElementById('button_event_2').addEventListener('click', () => {
+            this.emitEvent2();
+        });
+
+        // Set up socket message event handlers
+        this.webSocketWrapper = new WebSocketEventHandlers(this.socket, {
+            status_message: (data) => { console.log('WEB: status event:', data.message); this.updateStatus(data.message) },
+            server_message_1: (data) => { this.handleServerMessage1(data) },
+            server_message_2: (data) => { this.handleServerMessage2(data) }
+        });
+    }
+}
+

--- a/flask/ocio/static/js/materialx_ocio_app.js
+++ b/flask/ocio/static/js/materialx_ocio_app.js
@@ -20,7 +20,7 @@ export class MaterialXOCIOClient extends WebSocketClient {
             const wrapperDiv = document.createElement('div');
             wrapperDiv.classList.add('overflow-auto');
             wrapperDiv.style.maxWidth = '100%';
-            wrapperDiv.style.maxHeight = '400px';
+            wrapperDiv.style.maxHeight = '300px';
 
             // Move the table inside the wrapper div
             table.parentNode.insertBefore(wrapperDiv, table);
@@ -83,6 +83,18 @@ export class MaterialXOCIOClient extends WebSocketClient {
         this.updateMaterialXInfo(data.message);
     }
 
+    handleServerVersionInfo(data) {
+        this.updateStatus("Received server version info");
+
+        const ocio_version = document.getElementById('ocio_version');
+        const ocio_image = '<img src="https://opencolorio.org/images/ocio_m2x.png" width="48px"></img>';
+        ocio_version.innerHTML = ocio_image + ' version: ' + data.ocio_version;
+
+        const materialx_version = document.getElementById('materialx_version');
+        const mtlx_image = '<img src="https://materialx.org/LogoImages/MaterialXLogo2K.png" width="48px">';
+        materialx_version.innerHTML = mtlx_image + ' version: ' + data.materialx_version;
+    }   
+
     setupEventHandlers() {
         // Setup clear status button
         document.getElementById('clear_status').addEventListener('click', () => {
@@ -97,12 +109,16 @@ export class MaterialXOCIOClient extends WebSocketClient {
             this.getMaterialXInfo();
         });
 
+
         // Set up socket message event handlers
         this.webSocketWrapper = new WebSocketEventHandlers(this.socket, {
             status_message: (data) => { console.log('WEB: status event:', data.message); this.updateStatus(data.message) },
             server_message_get_config_info: (data) => { this.handleServerConfigInfo(data) },
-            server_message_get_mtlx_info: (data) => { this.handleServerMaterialXInfo(data) }
+            server_message_get_mtlx_info: (data) => { this.handleServerMaterialXInfo(data) },
+            server_message_version_info: (data) => { this.handleServerVersionInfo(data) }
         });
+
+        this.emit('client_event_get_version_info');
     }
     
     setupXML() {

--- a/flask/ocio/static/js/materialx_ocio_app.js
+++ b/flask/ocio/static/js/materialx_ocio_app.js
@@ -1,18 +1,54 @@
-import { WebSocketClient,  WebSocketEventHandlers } from './WebSocketClient.js';
+import { WebSocketClient, WebSocketEventHandlers } from './WebSocketClient.js';
 
-export class templateClient extends WebSocketClient
-{
+export class templateClient extends WebSocketClient {
     constructor(socketLibrary, server) {
         // Call parent to setup socket I/O.
         super(socketLibrary, server);
-        
+
         // Do other setup
     }
 
-    updateStatus(message, force = false) 
-    {
+    convertTableToBootstrapRowCol(container) {
+        // Modify the table to make it scrollable using Bootstrap classes
+        const tables = container.querySelectorAll('table');
+        tables.forEach(table => {
+            // Add Bootstrap table classes
+            table.classList.add('table', 'table-dark', 'table-bordered', 'table-hover', 'table-striped');
+
+            // Wrap the table in a div with Bootstrap's 'overflow-auto' class
+            const wrapperDiv = document.createElement('div');
+            wrapperDiv.classList.add('overflow-auto');
+            wrapperDiv.style.maxWidth = '100%';
+            wrapperDiv.style.maxHeight = '400px';
+
+            // Move the table inside the wrapper div
+            table.parentNode.insertBefore(wrapperDiv, table);
+            wrapperDiv.appendChild(table);
+
+            // Add a Bootstrap color class to the table header
+            const thead = table.querySelector('thead');
+            const headerColorClass = 'table-primary'; 
+            if (thead) {
+                thead.classList.add(headerColorClass);
+            } else {
+                const firstRow = table.querySelector('tr');
+                if (firstRow) {
+                    firstRow.classList.add(headerColorClass); 
+                }
+            }
+        });
+    }
+
+    updateConfigInfo(message) {
+        const html = marked.parse(message);
+        const configDOM = document.getElementById('config_info')
+        configDOM.innerHTML = html;
+        this.convertTableToBootstrapRowCol(configDOM);
+    }
+
+    updateStatus(message, force = false) {
         const inputDOM = document.getElementById('status_message');
-        if (inputDOM.value == 'Status' || force)        
+        if (inputDOM.value == 'Status' || force)
             inputDOM.value = message
         else
             inputDOM.value += '\n' + message
@@ -30,16 +66,14 @@ export class templateClient extends WebSocketClient
         this.emit('client_event_2', { message: "event 2" });
     }
 
-    handleServerMessage1(data)
-    {
+    handleServerMessage1(data) {
         console.log("WEB: Receive server message 1");
-        this.updateStatus(data.message);
+        this.updateConfigInfo(data.message);
     }
 
-    handleServerMessage2(data)
-    {
+    handleServerMessage2(data) {
         console.log("WEB: Receive server message 2");
-        this.updateStatus(data.message);       
+        this.updateStatus(data.message);
     }
 
     setupEventHandlers() {

--- a/flask/ocio/templates/materialx_ocio_app.html
+++ b/flask/ocio/templates/materialx_ocio_app.html
@@ -8,7 +8,7 @@
 
     <!-- See https://cdnjs.com/libraries/codemirror for other options-->
     <!--StyleStart-->
-    <title id="page_title">MaterialX OCIO Application</title>
+    <title id="page_title">MaterialX OCIO Utilities</title>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/6.65.7/codemirror.min.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/6.65.7/theme/night.min.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/6.65.7/theme/dracula.min.css">
@@ -42,14 +42,13 @@
 
 <body>
     <div class="container-fluid p-4">
-        <h2 id="title">MaterialX OCIO Application</h2>
+        <h2 id="title">MaterialX OCIO Utilities</h2>
         <div class="row pb-2 pt-2">
-            <div class="col-sm-11">
-                <textarea id="status_message" rows="2" readonly class="form-control small_text">Status</textarea>
-                </textarea>
+            <div class="col-sm py-0">
+                <div readonly id="ocio_version"></div>
             </div>
-            <div class="col-sm-1 py-0">
-                <button id="clear_status" class="btn btn-sm btn-secondary">Clear</button>
+            <div class="col-sm py-0">
+                <div readonly id="materialx_version"></div>
             </div>
         </div>
         <div class="row pb-2 pt-2">
@@ -61,7 +60,19 @@
         <div class="row pb-2 pt-2">
             <div class="col-sm py-0">
                 <button id="button_event_get_materialx" class="btn btn-sm btn-primary">Generate MaterialX</button>
-                <textarea id="materialX_info" rows="20" class="mt-4 form-control small_text"></textarea>
+                <div id="config_info" class="container-fluid mt-4">
+                    <textarea id="materialX_info" rows="10" class="form-control small_text"></textarea>
+                </div>
+            </div>
+        </div>
+        <hr>
+        <div class="row pb-2 pt-2">
+            <div class="col-sm-11">
+                <textarea id="status_message" rows="1" readonly class="form-control small_text">Status</textarea>
+                </textarea>
+            </div>
+            <div class="col-sm-1 py-0">
+                <button id="clear_status" class="btn btn-sm btn-secondary">Clear</button>
             </div>
         </div>
     </div>

--- a/flask/ocio/templates/materialx_ocio_app.html
+++ b/flask/ocio/templates/materialx_ocio_app.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/css/bootstrap.min.css" rel="stylesheet">
+
+    <!-- See https://cdnjs.com/libraries/codemirror for other options-->
+    <!--StyleStart-->
+    <title id="page_title">Sample Flask App</title>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/6.65.7/codemirror.min.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/6.65.7/theme/night.min.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/6.65.7/theme/dracula.min.css">
+
+    <!-- <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/6.65.7/theme/monokai.min.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/6.65.7/theme/dracula.min.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/6.65.7/theme/material.min.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/6.65.7/theme/material-darker.min.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/6.65.7/theme/abbott.min.css">
+    -->
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/6.65.7/codemirror.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/6.65.7/mode/xml/xml.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/6.65.7/mode/json/json.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/6.65.7/mode/javascript/javascript.min.js"></script>
+
+    <style>
+        .CodeMirror {
+            font-size: 11px;
+            border: solid thin lightskyblue;
+            height: 50em;
+        }
+    </style>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/css/bootstrap.min.css" rel="stylesheet">
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/js/bootstrap.bundle.min.js"></script>
+
+    <!-- <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}"> -->
+    <!--StyleEnd-->
+</head>
+
+<body>
+    <div class="container-fluid p-4">
+        <h2 id="title">MaterialX OCIO Application</h2>
+        <div class="row pb-2 pt-2">
+            <div class="col-sm-11">
+                <textarea id="status_message" rows="2" readonly class="form-control small_text">Status</textarea>
+                </textarea>
+            </div>
+            <div class="col-sm-1 py-0">
+                <button id="clear_status" class="btn btn-sm btn-secondary">Clear</button>
+            </div>
+        </div>
+    </div>
+    <div class="container blue-bordered-container">
+        <div class="row">
+            <div class="col">
+                <button id="button_event_1" class="btn btn-sm btn-primary">Trigger Event 1</button>
+            </div>
+            <div class="col">
+                <button id="button_event_2" class="btn btn-sm btn-primary">Trigger Event 2</button>    
+            </div>
+        </div>
+    </div>
+
+    <!-- <script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/4.5.4/socket.io.js"></script> -->
+    <script src="https://cdn.jsdelivr.net/npm/jszip@3.7.1/dist/jszip.min.js"></script>
+    <script type="module">
+
+        import { templateClient } from "{{ url_for('static', filename='js/materialx_ocio_app.js') }}";
+
+        document.addEventListener("DOMContentLoaded", () => {
+            document.body.setAttribute('data-bs-theme', 'dark');
+
+            // Instantiate the client
+            const client = new templateClient("", "");
+        });
+    </script>
+</body>
+
+</html>

--- a/flask/ocio/templates/materialx_ocio_app.html
+++ b/flask/ocio/templates/materialx_ocio_app.html
@@ -60,8 +60,13 @@
         <div class="row pb-2 pt-2">
             <div class="col-sm py-0">
                 <button id="button_event_get_materialx" class="btn btn-sm btn-primary">Generate MaterialX</button>
-                <div id="config_info" class="container-fluid mt-4">
-                    <textarea id="materialX_info" rows="10" class="form-control small_text"></textarea>
+                <input id="checkbox_nodegraphs" type="checkbox" aria-label="Checkbox for following text input">
+                    Nodegraph Definitions
+                </input>
+                <div id="materialx_info" class="container-fluid mt-4">
+                    <textarea id="materialX_nodedef" rows="10" class="form-control small_text"></textarea>
+                    <textarea id="materialX_impl" rows="10" class="form-control small_text" style="display: none"></textarea>
+                    <textarea id="materialX_source" rows="10" class="form-control small_text" style="display: none"></textarea>
                 </div>
             </div>
         </div>

--- a/flask/ocio/templates/materialx_ocio_app.html
+++ b/flask/ocio/templates/materialx_ocio_app.html
@@ -8,7 +8,7 @@
 
     <!-- See https://cdnjs.com/libraries/codemirror for other options-->
     <!--StyleStart-->
-    <title id="page_title">Sample Flask App</title>
+    <title id="page_title">MaterialX OCIO Application</title>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/6.65.7/codemirror.min.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/6.65.7/theme/night.min.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/6.65.7/theme/dracula.min.css">
@@ -54,14 +54,14 @@
         </div>
         <div class="row pb-2 pt-2">
             <div class="col-sm py-0">
-                <button id="button_event_1" class="btn btn-sm btn-primary">Get Configurations</button>
+                <button id="button_event_get_config" class="btn btn-sm btn-primary">Get Configurations</button>
                 <div id="config_info" class="container-fluid mt-4"></div>
             </div>
         </div>
         <div class="row pb-2 pt-2">
             <div class="col-sm py-0">
-                <button id="button_event_2" class="btn btn-sm btn-primary">Generate MaterialX</button>
-                <div id="materialX_info" class="container-fluid mt-4"></div>
+                <button id="button_event_get_materialx" class="btn btn-sm btn-primary">Generate MaterialX</button>
+                <textarea id="materialX_info" rows="20" class="mt-4 form-control small_text"></textarea>
             </div>
         </div>
     </div>

--- a/flask/ocio/templates/materialx_ocio_app.html
+++ b/flask/ocio/templates/materialx_ocio_app.html
@@ -42,7 +42,11 @@
 
 <body>
     <div class="container-fluid p-4">
-        <h2 id="title">MaterialX OCIO Utilities</h2>
+        <h2 id="title">MaterialX OCIO Utilities (Alpha)</h2>
+        <p>This package is still work in progress for node graph generation.
+            The basics of usage are in the package and server side wrapping
+            can be examined / used.
+        </p>
         <div class="row pb-2 pt-2">
             <div class="col-sm py-0">
                 <div readonly id="ocio_version"></div>
@@ -60,7 +64,7 @@
         <div class="row pb-2 pt-2">
             <div class="col-sm py-0">
                 <button id="button_event_get_materialx" class="btn btn-sm btn-primary">Generate MaterialX</button>
-                <input id="checkbox_nodegraphs" type="checkbox" aria-label="Checkbox for following text input">
+                <input id="checkbox_nodegraphs" type="checkbox" checked="True" aria-label="Checkbox for following text input">
                     Nodegraph Definitions
                 </input>
                 <div id="materialx_info" class="container-fluid mt-4">

--- a/flask/ocio/templates/materialx_ocio_app.html
+++ b/flask/ocio/templates/materialx_ocio_app.html
@@ -70,13 +70,14 @@
     <script src="https://cdn.jsdelivr.net/npm/jszip@3.7.1/dist/jszip.min.js"></script>
     <script type="module">
 
-        import { templateClient } from "{{ url_for('static', filename='js/materialx_ocio_app.js') }}";
+        import { MaterialXOCIOClient } from "{{ url_for('static', filename='js/materialx_ocio_app.js') }}";
 
         document.addEventListener("DOMContentLoaded", () => {
             document.body.setAttribute('data-bs-theme', 'dark');
 
             // Instantiate the client
-            const client = new templateClient("", "");
+            const client = new MaterialXOCIOClient("", "");
+            client.setupXML();
         });
     </script>
 </body>

--- a/flask/ocio/templates/materialx_ocio_app.html
+++ b/flask/ocio/templates/materialx_ocio_app.html
@@ -34,6 +34,8 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/css/bootstrap.min.css" rel="stylesheet">
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/js/bootstrap.bundle.min.js"></script>
 
+    <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+
     <!-- <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}"> -->
     <!--StyleEnd-->
 </head>
@@ -50,14 +52,16 @@
                 <button id="clear_status" class="btn btn-sm btn-secondary">Clear</button>
             </div>
         </div>
-    </div>
-    <div class="container blue-bordered-container">
-        <div class="row">
-            <div class="col">
-                <button id="button_event_1" class="btn btn-sm btn-primary">Trigger Event 1</button>
+        <div class="row pb-2 pt-2">
+            <div class="col-sm py-0">
+                <button id="button_event_1" class="btn btn-sm btn-primary">Get Configurations</button>
+                <div id="config_info" class="container-fluid mt-4"></div>
             </div>
-            <div class="col">
-                <button id="button_event_2" class="btn btn-sm btn-primary">Trigger Event 2</button>    
+        </div>
+        <div class="row pb-2 pt-2">
+            <div class="col-sm py-0">
+                <button id="button_event_2" class="btn btn-sm btn-primary">Generate MaterialX</button>
+                <div id="materialX_info" class="container-fluid mt-4"></div>
             </div>
         </div>
     </div>


### PR DESCRIPTION
# Flask OCIO Example

- Uses the materialxocio library example
- Note that this is marked as "alpha" since not all operations for nodegraph generation have been completed.
- Formatting for source code generation still be be cleaned up.
